### PR TITLE
fix: widen tea column widths on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,10 +86,10 @@
 
   /* スマホ時は少し比率調整 */
   @media (max-width:640px){
-    #teaTable .col-name{width:17%}
-    #teaTable .col-type{width:17%}
-    #teaTable .col-note{width:15%}
-    #teaTable .col-weight{width:12%}
+    #teaTable .col-name{width:25%}
+    #teaTable .col-type{width:20%}
+    #teaTable .col-note{width:8%}
+    #teaTable .col-weight{width:5%}
     .teaTableWrap{overflow:visible;max-height:none;}
   }
   @media (max-width:768px), (hover:none) and (pointer:coarse) {


### PR DESCRIPTION
## Summary
- widen tea list name and type columns on small screens so product names and origins remain visible

## Testing
- `npx --yes html-validate index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html-validate)*

------
https://chatgpt.com/codex/tasks/task_e_68ab43d0366c832790ba3d2e27b39bda