### PR TITLE
fix: hide detail toggle on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,14 +37,13 @@
 /* 合計 100% 版（削除ボタンが確実に見える配分） */
 #teaTable { table-layout: fixed; }
 #teaTable td, #teaTable th { overflow: hidden; }
-#teaTable .col-name   { width:16%; }  /* 商品名 */
-#teaTable .col-brand  { width:11%; }
-#teaTable .col-type   { width:15%; }
-#teaTable .col-detail { width:6%;  }
+#teaTable .col-name   { width:18%; }  /* 商品名 */
+#teaTable .col-brand  { width:12%; }
+#teaTable .col-type   { width:16%; }
 #teaTable .col-caf    { width:8%;  }
 #teaTable .col-stock  { width:8%;  }
-#teaTable .col-date   { width:13%; }
-#teaTable .col-note   { width:13%; }  /* メモ */
+#teaTable .col-date   { width:14%; }
+#teaTable .col-note   { width:14%; }  /* メモ */
 #teaTable .col-weight { width:10%;  }  /* 重み＋削除 */
 
   /* セル内フォームはセルに収める */
@@ -87,6 +86,12 @@
 
   .pc-only{display:inline;}
   .sp-only{display:none;}
+
+  /* PCでは詳細ボタン/列を非表示 */
+  #teaTable .col-detail,
+  #teaTable th:nth-child(4),
+  #teaTable td:nth-child(4){display:none;}
+  .toggle-details{display:none;margin-top:4px;color:#2b7cff;background:none;border:none;cursor:pointer;font-size:12px;text-decoration:underline;}
 
   /* スマホ時は少し比率調整 */
   @media (max-width:640px){
@@ -145,8 +150,6 @@
   .item .del{border:1px solid #b00020;background:#fff;color:#b00020;font-size:14px;border-radius:6px;cursor:pointer;padding:2px 6px}
   .row{display:flex;gap:6px;margin-top:6px}
 
-  .toggle-details{display:inline-block;margin-top:4px;color:#2b7cff;background:none;border:none;cursor:pointer;font-size:12px;text-decoration:underline;}
-
   .toggle-details.bottom{margin-top:8px;text-align:right;width:100%;}
 
 
@@ -192,6 +195,7 @@
     padding: 8px 4px;
     background: transparent;
   }
+  #teaTable td:nth-child(4){display:grid;}
   #teaTable td::before { display: none; }
   /* 7列目以降は横幅いっぱいに、5-6列目（カフェイン・在庫）は横並び（比率50%） */
   #teaTable tr td:nth-child(-n+4){grid-column:span 2;}


### PR DESCRIPTION
## Summary
- restore desktop column widths and remove detail column
- limit collapsible detail toggle to mobile view only

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac13eea8fc8327b1c651fc9ef4a924