### PR TITLE
Expand desktop card width for tea picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
   .btn.danger{color:#b00020;border-color:#b00020}
   .wrap{padding:var(--pad);max-width:1100px;margin:0 auto}
   .card{background:#fff;border:1px solid #e4e7ee;border-radius:var(--radius);padding:var(--pad);box-shadow:var(--shadow);margin:0 auto 12px;max-width:500px}
+  @media (min-width:641px){
+    .card{max-width:900px;}
+  }
   .tabs{display:flex;gap:6px;margin-bottom:8px;flex-wrap:wrap}
   .tab{padding:8px 12px;border-radius:999px;border:1px solid #d0d6e0;background:#fff;cursor:pointer}
   .tab.active{background:#111;color:#fff;border-color:#111}


### PR DESCRIPTION
## Summary
- Widen desktop card widgets so selection lists align and fit on screen

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac16b30f1083278a26f43351957ea0