### PR TITLE
Fix filter select widths for balance

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,8 @@
   .item .label{flex:1}
   .item .del{border:1px solid #b00020;background:#fff;color:#b00020;font-size:14px;border-radius:6px;cursor:pointer;padding:2px 6px}
   .row{display:flex;gap:6px;margin-top:6px}
+  #fType,
+  #fBrand{width:160px}
 
   .toggle-details.bottom{margin-top:8px;text-align:right;width:100%;}
 


### PR DESCRIPTION
## Summary
- Set uniform width for type and brand filters on draw screen to improve layout balance.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1d5042e48327964a65f1d3e8ce7d