### PR TITLE
Register service worker on DOM content load

### DIFF
--- a/index.html
+++ b/index.html
@@ -1373,5 +1373,18 @@ renderAll();
 </script>
 
 
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('sw.js')
+      .then(reg => console.log('Service worker registered:', reg))
+      .catch(err => console.error('Service worker registration failed:', err));
+  } else {
+    console.log('Service workers are not supported in this browser.');
+  }
+});
+</script>
+
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Register service worker `sw.js` after DOMContentLoaded and log success/failure.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1f57116c83279caa693b41ea94d5