### PR TITLE
Center cards on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
     .teaTableWrap{overflow:visible;max-height:none;}
     .pc-only{display:none;}
     .sp-only{display:inline;}
+    .card{width:90%;}
   }
   @media (max-width:768px), (hover:none) and (pointer:coarse) {
   .fab { display: none !important; }


### PR DESCRIPTION
## Summary
- adjust mobile layout to center cards by giving them 90% width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac20a47ca883279a6a91742658782a