### PR TITLE
Fix memo textarea size and add placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
     <div id="drawResult">まだ抽選していません。</div>
     <div id="memoArea" style="display:none;margin-top:8px">
       <div id="memoDisplay" style="margin-bottom:6px"></div>
-      <textarea id="memoInput" rows="2" style="width:100%;border-radius:6px;border:1px solid #c8cdd6;"></textarea>
+      <textarea id="memoInput" rows="5" placeholder="メモを追加" style="width:100%;border-radius:6px;border:1px solid #c8cdd6;resize:none;"></textarea>
       <button id="btnSave" class="btn primary" style="margin-top:6px">確定して履歴に追加</button>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Show post-draw memo textarea with 5 lines and placeholder text
- Disable manual resizing of the memo textarea

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2de741c483279ae4e863f1ccb89f