### PR TITLE
Center cards on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
     .teaTableWrap{overflow:visible;max-height:none;}
     .pc-only{display:none;}
     .sp-only{display:inline;}
-    .card{width:90%;}
+    .card{width:90%;margin-left:auto;margin-right:auto;}
   }
   @media (max-width:768px), (hover:none) and (pointer:coarse) {
   .fab { display: none !important; }


### PR DESCRIPTION
## Summary
- ensure cards are centered on small screens by adding automatic left/right margins

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac34069a448327811387396684fc69