### PR TITLE
Center tea body container

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,8 @@
   th{background:#fafbfc;position:sticky;top:0;z-index:1}
 
   .teaTableWrap{overflow:auto;max-height:60vh;display:flex;justify-content:center;}
-  #teaTable{margin-left:auto;margin-right:auto;}
+  #teaTable{width:auto;margin-left:auto;margin-right:auto;}
+  #teaBody{display:block;margin-left:auto;margin-right:auto;}
 
   /* 入力セルの背景 */
   td.editable,


### PR DESCRIPTION
## Summary
- Center the tea table body itself by adjusting `#teaBody` to be a block with auto margins
- Override global table width so `#teaTable` shrinks to fit content and remains centered

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/tea-picker/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ac73767f088327a1a488ce4e88e00f