### PR TITLE
Restore desktop tea list spacing and tighten mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,12 +27,11 @@
   .subtab{padding:6px 10px;border-radius:999px;border:1px solid #ccc;background:#fff;cursor:pointer;font-size:13px}
   .subtab.active{background:#2b2f36;color:#fff;border-color:#2b2f36}
   table{width:100%;border-collapse:collapse}
-  th,td{border-bottom:1px solid #eef1f6;padding:2px 4px;text-align:left;font-size:14px;vertical-align:top}
+  th,td{border-bottom:1px solid #eef1f6;padding:6px;text-align:left;font-size:14px;vertical-align:top}
   th{background:#fafbfc;position:sticky;top:0;z-index:1}
 
   .teaTableWrap{overflow:auto;max-height:60vh;display:flex;justify-content:center;}
-  #teaTable{width:auto;margin-left:auto;margin-right:auto;}
-  #teaBody{display:block;margin-left:auto;margin-right:auto;}
+  #teaTable{margin-left:auto;margin-right:auto;}
 
 
   /* 入力セルの背景 */
@@ -61,9 +60,9 @@
   #teaTable select{
     width:100%; max-width:100%; min-width:0;
     box-sizing:border-box;
-    border:1px solid #c8cdd6; border-radius:6px; background:#fff; padding:2px 4px;
+    border:1px solid #c8cdd6; border-radius:6px; background:#fff; padding:6px 8px;
   }
-  #teaTable select{padding:2px 4px}
+  #teaTable select{padding:4px 8px}
   #teaTable input[type="text"]:focus,
   #teaTable input[type="number"]:focus,
   #teaTable input[type="date"]:focus,
@@ -80,7 +79,7 @@
     white-space:normal;overflow:visible;text-overflow:clip;
   }
   /* 行削除ボタン＆倍率セルの横並び */
-  #teaTable .weightWrap{display:flex;gap:2px;align-items:center}
+  #teaTable .weightWrap{display:flex;gap:6px;align-items:center}
   #teaTable .weightWrap input[type="number"]{flex:1}
   #teaTable .row-del{
   border:1px solid #b00020;background:#fff;color:#b00020;
@@ -196,20 +195,20 @@
   #teaTable tr {
     display: grid;
     grid-template-columns: repeat(2,1fr);
-    gap: 8px;
-    margin: 10px 0;
+    gap: 4px;
+    margin: 4px 0;
     border: 1px solid #e4e7ee;
     border-radius: 10px;
-    padding: 8px;
+    padding: 4px;
     background: #fff;
     box-shadow: var(--shadow);
   }
   #teaTable td {
     display: grid;
     grid-template-columns: 1fr; /* ラベルを上に配置 */
-    gap: 4px;
+    gap: 2px;
     border: 0;
-    padding: 8px 4px;
+    padding: 4px 2px;
     background: transparent;
   }
   #teaTable td:nth-child(5){display:grid;}
@@ -241,6 +240,7 @@
   #teaTable input[type="date"],
   #teaTable select {
     width: 100%;
+    padding: 2px 4px;
   }
 
   /* 倍率＋削除を縦にも並べやすく */
@@ -249,11 +249,11 @@
     grid-template-columns: 1fr;
     gap: 2px;
     align-items: stretch;
-    margin-top: 4px;
+    margin-top: 2px;
   }
   #teaTable .weightWrap .row-del {
     width: 100%;
-    padding: 8px 12px;
+    padding: 4px 6px;
   }
 
   /* 抽選フィルタ行は縦積み */


### PR DESCRIPTION
## Summary
- Revert desktop tea list to original spacing and layout
- Shrink extra margins and padding in mobile tea list cards

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac824040608327b688ad3c7adf1e07