### PR TITLE
Add mobile add-row button at bottom of tea list

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,6 +361,9 @@
         <tbody id="teaBody"></tbody>
       </table>
     </div>
+    <div class="sp-only" style="margin-top:8px;text-align:center;">
+      <button id="btnAddRowBottom" class="btn">＋ 行を追加</button>
+    </div>
   </section>
 
   <!-- 履歴 -->
@@ -957,6 +960,7 @@ function addRow(){
 
 // 追加ボタン
 $("#btnAddRow")?.addEventListener("click", addRow);
+$("#btnAddRowBottom")?.addEventListener("click", addRow);
 
 // 行の削除（イベント委任）
 $("#teaBody").addEventListener("click", (e)=>{


### PR DESCRIPTION
## Summary
- add mobile-only add-row button after tea list so users on phones don't need to scroll back up
- wire bottom button to existing addRow handler

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac91b1972083278c6d3c13a9857659